### PR TITLE
Issue 4 - add CI for MW 1.43

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,12 +17,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - mediawiki_version: '1.35'
-            php_version: 7.4
-            database_type: mysql
-            database_image: "mysql:5.7"
-            coverage: false
-            experimental: false
           - mediawiki_version: '1.39'
             php_version: 8.1
             database_type: mysql

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,13 @@ jobs:
             coverage: false
             experimental: false
           - mediawiki_version: '1.42'
-            php_version: 8.1
+            php_version: 8.2
+            database_type: mysql
+            database_image: "mysql:8"
+            coverage: false
+            experimental: false
+          - mediawiki_version: '1.43'
+            php_version: 8.2
             database_type: mysql
             database_image: "mysql:8"
             coverage: false

--- a/composer.json
+++ b/composer.json
@@ -30,5 +30,10 @@
 		"phpunit": "php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist --testdox",
 		"phpunit-coverage": "php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist --testdox --coverage-text --coverage-html coverage/php --coverage-clover coverage/php/coverage.xml",
 		"minus-x": "minus-x check ."
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	}
 }

--- a/src/EditWarningApi.php
+++ b/src/EditWarningApi.php
@@ -4,6 +4,7 @@ namespace EditWarning;
 
 use ApiBase;
 use Exception;
+use MediaWiki\MediaWikiServices;
 use User;
 
 class EditWarningApi extends ApiBase {
@@ -27,7 +28,7 @@ class EditWarningApi extends ApiBase {
 		}
 
 		try {
-			$dbw = wfGetDB( DB_MASTER );
+			$dbw = MediaWikiServices::getInstance()->getDBLoadBalancer()->getConnection( DB_PRIMARY );
 			$ew->removeLock( $dbw );
 
 			if ( $ewAction === 'lock' ) {


### PR DESCRIPTION
This PR is related to the issue #4.

This PR contains:

- deprecated DB_MASTER replaced with DB_PRIMARY
- `main.yml` updated
- drop support for MW 1.35